### PR TITLE
Add forecast_days query parameter

### DIFF
--- a/OpenMeteo/OpenMeteoClient.cs
+++ b/OpenMeteo/OpenMeteoClient.cs
@@ -354,8 +354,11 @@ namespace OpenMeteo
 
             uri.Query += "&timeformat=" + options.Timeformat.ToString();
 
-            uri.Query += "&past_days=" + options.Past_Days;
-            uri.Query += "&forecast_days=" + options.Forecast_Days;
+            if (string.IsNullOrEmpty(options.Start_date) && string.IsNullOrEmpty(options.End_date))
+			{
+				uri.Query += "&past_days=" + options.Past_Days;
+				uri.Query += "&forecast_days=" + options.Forecast_Days;
+			}
 
             if (options.Start_date != string.Empty)
                 uri.Query += "&start_date=" + options.Start_date;

--- a/OpenMeteo/OpenMeteoClient.cs
+++ b/OpenMeteo/OpenMeteoClient.cs
@@ -355,6 +355,7 @@ namespace OpenMeteo
             uri.Query += "&timeformat=" + options.Timeformat.ToString();
 
             uri.Query += "&past_days=" + options.Past_Days;
+            uri.Query += "&forecast_days=" + options.Forecast_Days;
 
             if (options.Start_date != string.Empty)
                 uri.Query += "&start_date=" + options.Start_date;

--- a/OpenMeteo/WeatherForecastOptions.cs
+++ b/OpenMeteo/WeatherForecastOptions.cs
@@ -61,9 +61,16 @@ namespace OpenMeteo
 
         /// <summary>
         /// Default is "0". Other options: "1", "2"
+        /// Maximum: 92.
         /// </summary>
         /// <value></value>
         public int Past_Days { get; set; }
+
+        /// <summary>
+        /// Default is 7 days, even if not included in query.
+        /// Maximum: 16.
+        /// </summary>
+        public int Forecast_Days { get; set; } = 7;
 
         /// <summary>
         /// The time interval to get weather data. A day must be specified as an ISO8601 date (e.g. 2022-06-30).


### PR DESCRIPTION
The forecast_days parameter allows for getting forecasts for a specific number of days in an easier way compared to using start and end dates.
Additionally adding a check to prevent both forecast_days and past_days to be included alongside start_date and end_date, as that causes an error to be returned by the openMeteo API.


